### PR TITLE
Feat: 공통 예외 처리 기능 추가 및 에러 응답 포맷 정리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,12 @@ dependencies {
     implementation "org.springframework:spring-tx:${springVersion}"
     testImplementation "org.springframework:spring-test:${springVersion}"
 
+    // Spring Test
+    testImplementation("org.springframework:spring-test:${springVersion}")
+    testImplementation("org.springframework:spring-webmvc:${springVersion}")
+    testImplementation("org.mockito:mockito-junit-jupiter:3.12.4")
+    testImplementation("org.hamcrest:hamcrest-all:1.3")
+
     // JUnit 5
     testImplementation("org.junit.jupiter:junit-jupiter-api:${junitVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junitVersion}")
@@ -69,7 +75,7 @@ dependencies {
     implementation "commons-codec:commons-codec:1.15"
 
     // Servlet & JSP
-    compileOnly "javax.servlet:javax.servlet-api:3.1.0"
+    implementation "javax.servlet:javax.servlet-api:3.1.0"
     compileOnly "javax.servlet.jsp:jsp-api:2.2"
     implementation "javax.servlet:jstl:${jstlVersion}"
 

--- a/src/main/java/me/jaesung/simplepg/common/exception/CustomException.java
+++ b/src/main/java/me/jaesung/simplepg/common/exception/CustomException.java
@@ -1,0 +1,58 @@
+package me.jaesung.simplepg.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(ErrorCode errorCode, String customMessage) {
+        super(customMessage);
+        this.errorCode = errorCode;
+    }
+
+    public HttpStatus getStatus() {
+        return errorCode.getHttpStatus();
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+
+    /**
+     * 잘못된 요청 파라미터 (400 Bad Request)
+     */
+    public static class InvalidRequestException extends CustomException {
+        public InvalidRequestException(String message) {
+            super(ErrorCode.INVALID_REQUEST, message);
+        }
+
+    }
+
+    /**
+     * 인증 실패 (401 Unauthorized)
+     */
+    public static class UnauthorizedException extends CustomException {
+        public UnauthorizedException(String message) {
+            super(ErrorCode.UNAUTHORIZED, message);
+        }
+
+    }
+
+    /**
+     * 리소스를 찾을 수 없음 (404 Not Found)
+     */
+    public static class NotFoundException extends CustomException {
+        public NotFoundException(String message) {
+            super(ErrorCode.NOT_FOUND, message);
+        }
+
+    }
+
+}

--- a/src/main/java/me/jaesung/simplepg/common/exception/ErrorCode.java
+++ b/src/main/java/me/jaesung/simplepg/common/exception/ErrorCode.java
@@ -1,0 +1,22 @@
+package me.jaesung.simplepg.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    INVALID_REQUEST("Invalid request parameters", HttpStatus.BAD_REQUEST),
+    UNAUTHORIZED("Authentication failed", HttpStatus.UNAUTHORIZED),
+    NOT_FOUND("Resource not found", HttpStatus.NOT_FOUND),
+    INTERNAL_SERVER_ERROR("An unexpected error", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    ErrorCode(String message, HttpStatus httpStatus) {
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+}

--- a/src/main/java/me/jaesung/simplepg/common/exception/ErrorResponse.java
+++ b/src/main/java/me/jaesung/simplepg/common/exception/ErrorResponse.java
@@ -1,0 +1,28 @@
+package me.jaesung.simplepg.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ErrorResponse {
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime timestamp;
+    private int status;
+    private String message;
+    private String path;
+
+    public static ErrorResponse of(int status, String message, String path) {
+        return ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(status)
+                .message(message)
+                .path(path)
+                .build();
+    }
+
+}

--- a/src/main/java/me/jaesung/simplepg/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/me/jaesung/simplepg/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,78 @@
+package me.jaesung.simplepg.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * Api 예외 처리 핸들러
+     */
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException ex, WebRequest request) {
+
+        ErrorCode errorCode = ex.getErrorCode();
+        HttpStatus status = errorCode.getHttpStatus();
+        String path = getRequestURI(request);
+
+        log.error("Custom exception occurred: status={}, URI={}",
+                status, path, ex);
+
+        ErrorResponse errorResponse = ErrorResponse.of(status.value(), ex.getMessage(), path);
+        return ResponseEntity.status(status).body(errorResponse);
+    }
+
+    /**
+     * 파라미터 검증 예외 처리 핸들러
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMAValidException(MethodArgumentNotValidException ex, WebRequest request) {
+
+        ErrorCode errorCode = ErrorCode.INVALID_REQUEST;
+        HttpStatus status = errorCode.getHttpStatus();
+        String path = getRequestURI(request);
+
+        log.error("MethodArgumentNotValid exception occurred: status={}, URI={}",
+                status, path, ex);
+
+        ErrorResponse errorResponse = ErrorResponse.of(status.value(), "파라미터의 형식이 틀립니다.", path);
+        return ResponseEntity.status(status).body(errorResponse);
+    }
+
+
+    /**
+     * 전역 예외 처리 핸들러
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGlobalException(Exception ex, WebRequest request) {
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        HttpStatus status = errorCode.getHttpStatus();
+        String path = getRequestURI(request);
+
+        log.error("Unhandled exception occurred: code={}, status={}, URI={}",
+                errorCode.name(), status, path, ex);
+
+        ErrorResponse errorResponse = ErrorResponse.of(status.value(), "서버 측 예외 발생", path);
+
+        return ResponseEntity.status(status).body(errorResponse);
+    }
+
+    /**
+     * Request에서 URI 추출
+     */
+    private String getRequestURI(WebRequest request) {
+        if (request instanceof ServletWebRequest) {
+            return ((ServletWebRequest) request).getRequest().getRequestURI();
+        }
+        return "";
+    }
+}


### PR DESCRIPTION
## ✨ PR 개요

전역 공통 예외 처리 기능을 추가하여, API 응답의 일관성을 유지하고 유지보수성을 높였습니다.  
예외 발생 시 클라이언트에 정형화된 에러 응답을 제공하고, 로그를 통해 예외 추적이 가능하도록 구현하였습니다.

---

## 🔧 주요 변경 사항

- `GlobalExceptionHandler` 클래스 추가 (`@RestControllerAdvice` 기반)
  - `CustomException`, `MethodArgumentNotValidException`, `Exception`에 대한 핸들링 처리
  - 요청 URI 포함 로그 출력 및 응답 포맷 구성
- `CustomException` 및 하위 커스텀 예외 클래스 3종 추가
  - `InvalidRequestException`, `UnauthorizedException`, `NotFoundException`
- `ErrorCode` enum 클래스 생성
  - 각 예외 상황에 따른 메시지 및 HTTP 상태코드 정의
- `ErrorResponse` DTO 생성
  - 응답 필드: `timestamp`, `status`, `message`, `path`
  - 정적 팩토리 메서드를 통해 응답 객체 구성

---

## 🧪 테스트 시나리오

- 유효하지 않은 파라미터(`@Valid`) 전송 시 → 400 Bad Request 응답 및 `"파라미터의 형식이 틀립니다."` 메시지 확인
- 존재하지 않는 리소스 접근 시 → 404 Not Found 응답
- API 키 인증 실패 시 → 401 Unauthorized 응답
- 처리되지 않은 예외 발생 시 → 500 Internal Server Error 응답

---

## 📁 관련 파일 경로

└── me.jaesung.simplepg.common.exception ├── CustomException.java ├── ErrorCode.java ├── ErrorResponse.java └── GlobalExceptionHandler.java


---

## 📝 참고 사항

- 추가로 처리해야 할 예외 유형이 있다면 `CustomException` 하위 클래스로 확장 가능합니다.
- 로그 레벨은 현재 `ERROR`로 설정되어 있으며, 필요 시 운영환경에 맞게 조정하면 됩니다.