### PR TITLE
Feat: 서비스 웹훅 처리 및 결제 결과 알림 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ ext {
 }
 
 dependencies {
+
     // Spring
     implementation("org.springframework:spring-context:${springVersion}") {
         exclude group: 'commons-logging', module: 'commons-logging'
@@ -35,6 +36,11 @@ dependencies {
     implementation "org.springframework:spring-jdbc:${springVersion}"
     implementation "org.springframework:spring-tx:${springVersion}"
     testImplementation "org.springframework:spring-test:${springVersion}"
+
+    // Spring Webflux
+    implementation 'io.projectreactor:reactor-core:3.4.0'
+    implementation 'org.springframework:spring-webflux:5.3.10'
+    implementation 'io.projectreactor.netty:reactor-netty:1.0.24'
 
     // Spring Test
     testImplementation("org.springframework:spring-test:${springVersion}")

--- a/src/main/java/me/jaesung/simplepg/common/exception/ErrorCode.java
+++ b/src/main/java/me/jaesung/simplepg/common/exception/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode {
     NOT_FOUND("Resource not found", HttpStatus.NOT_FOUND),
     INTERNAL_SERVER_ERROR("An unexpected error", HttpStatus.INTERNAL_SERVER_ERROR),
     REQUEST_TIMEOUT("Request Timeout", HttpStatus.REQUEST_TIMEOUT),
-    KEY_CONFLICT("Key Conflict", HttpStatus.CONFLICT);
+    KEY_CONFLICT("Key Conflict", HttpStatus.CONFLICT),
+    BAD_GATEWAY("Bad GateWay", HttpStatus.BAD_GATEWAY);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/src/main/java/me/jaesung/simplepg/common/exception/PaymentException.java
+++ b/src/main/java/me/jaesung/simplepg/common/exception/PaymentException.java
@@ -36,4 +36,12 @@ public class PaymentException extends RuntimeException{
     public static class ProcessingException extends PaymentException{
         public ProcessingException(String message) {super(ErrorCode.INTERNAL_SERVER_ERROR, message);}
     }
+
+    public static class ExternalPaymentException extends PaymentException{
+        public ExternalPaymentException(String message) {super(ErrorCode.BAD_GATEWAY, message);}
+    }
+
+    public static class WebhookProcessingException extends PaymentException{
+        public WebhookProcessingException(String message) {super(ErrorCode.INTERNAL_SERVER_ERROR, message);}
+    }
 }

--- a/src/main/java/me/jaesung/simplepg/common/util/DateTimeUtil.java
+++ b/src/main/java/me/jaesung/simplepg/common/util/DateTimeUtil.java
@@ -1,0 +1,25 @@
+package me.jaesung.simplepg.common.util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class DateTimeUtil {
+
+    public static LocalDateTime parse(String dateTimeStr, String pattern) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
+        return LocalDateTime.parse(dateTimeStr, formatter);
+    }
+    private static final DateTimeFormatter DEFAULT_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    public static LocalDateTime parseDefault(String dateTimeStr) {
+        return LocalDateTime.parse(dateTimeStr, DEFAULT_FORMATTER);
+    }
+
+    private static final DateTimeFormatter ISO_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+    public static LocalDateTime parseIso(String dateTimeStr) {
+        return LocalDateTime.parse(dateTimeStr, ISO_FORMATTER);
+    }
+}

--- a/src/main/java/me/jaesung/simplepg/common/util/HmacUtil.java
+++ b/src/main/java/me/jaesung/simplepg/common/util/HmacUtil.java
@@ -1,5 +1,6 @@
 package me.jaesung.simplepg.common.util;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.Mac;
@@ -17,7 +18,7 @@ public class HmacUtil {
     private static final String ALGORITHM = "HmacSHA256";
 
     public static String generateSignature(String data, String secretKey) throws Exception {
-        SecretKeySpec secretKeySpec = new SecretKeySpec(secretKey.getBytes(), ALGORITHM);
+        SecretKeySpec secretKeySpec = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), ALGORITHM);
         Mac mac = Mac.getInstance(ALGORITHM);
         mac.init(secretKeySpec);
         byte[] hmacData = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/me/jaesung/simplepg/config/AppConfig.java
+++ b/src/main/java/me/jaesung/simplepg/config/AppConfig.java
@@ -3,6 +3,7 @@ package me.jaesung.simplepg.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.netty.channel.ChannelOption;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.mybatis.spring.SqlSessionFactoryBean;
@@ -10,11 +11,16 @@ import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.*;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
-import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
 
 import javax.sql.DataSource;
+import java.time.Duration;
 
 @Configuration
 @Slf4j
@@ -68,6 +74,20 @@ public class AppConfig {
     public ObjectMapper objectMapper() {
         return new ObjectMapper();
     }
+
+    /**
+     * 연결 타임 아웃 : 5초 (RTT의 2~3배 권장)
+     * 응답 타임 아웃 : 60초
+     */
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(HttpClient.create()
+                        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+                        .responseTimeout(Duration.ofMillis(60000))))
+                .build();
+    }
+
 
 
 }

--- a/src/main/java/me/jaesung/simplepg/config/SecurityConfig.java
+++ b/src/main/java/me/jaesung/simplepg/config/SecurityConfig.java
@@ -1,9 +1,6 @@
 package me.jaesung.simplepg.config;
 
 import lombok.extern.slf4j.Slf4j;
-import me.jaesung.simplepg.common.util.filter.ApiAuthenticationFilter;
-import me.jaesung.simplepg.service.auth.ApiCredentialService;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;

--- a/src/main/java/me/jaesung/simplepg/config/ServletConfig.java
+++ b/src/main/java/me/jaesung/simplepg/config/ServletConfig.java
@@ -13,6 +13,7 @@ import org.springframework.web.servlet.config.annotation.*;
 @Configuration
 @PropertySource({"classpath:/application.properties"})
 @ComponentScan(basePackages = "me.jaesung.simplepg.controller")
+@ComponentScan(basePackages = "me.jaesung.simplepg.service")
 public class ServletConfig implements WebMvcConfigurer {
 
     @Value("${server.URI}")

--- a/src/main/java/me/jaesung/simplepg/controller/payment/PaymentController.java
+++ b/src/main/java/me/jaesung/simplepg/controller/payment/PaymentController.java
@@ -1,4 +1,4 @@
-package me.jaesung.simplepg.controller;
+package me.jaesung.simplepg.controller.payment;
 
 import lombok.RequiredArgsConstructor;
 import me.jaesung.simplepg.domain.dto.payment.PaymentInfoDTO;
@@ -24,7 +24,7 @@ public class PaymentController {
     }
 
     @GetMapping("/{paymentKey}")
-    public ResponseEntity<PaymentInfoDTO> getPaymentStatus(@PathVariable String paymentKey){
+    public ResponseEntity<PaymentInfoDTO> getPaymentStatus(@PathVariable String paymentKey) {
         PaymentInfoDTO paymentStatus = paymentService.getPaymentStatus(paymentKey);
         return ResponseEntity.ok(paymentStatus);
     }

--- a/src/main/java/me/jaesung/simplepg/controller/webhook/WebhookController.java
+++ b/src/main/java/me/jaesung/simplepg/controller/webhook/WebhookController.java
@@ -1,0 +1,31 @@
+package me.jaesung.simplepg.controller.webhook;
+
+import me.jaesung.simplepg.domain.dto.webhook.WebhookRequest;
+import me.jaesung.simplepg.service.webhook.WebhookService;
+import me.jaesung.simplepg.service.webhook.WebhookServiceFactory;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/api/protected/webhook")
+public class WebhookController {
+
+    private final WebhookServiceFactory webhookServiceFactory;
+
+    public WebhookController(WebhookServiceFactory webhookServiceFactory) {
+        this.webhookServiceFactory = webhookServiceFactory;
+    }
+
+    @PostMapping("/{paymentKey}/{webhookStatus}")
+    public void webhookProcess(
+            @PathVariable String paymentKey,
+            @PathVariable String webhookStatus,
+            @RequestBody WebhookRequest webhookRequest) {
+
+        WebhookService webhookService = webhookServiceFactory.getWebhookService(webhookStatus);
+
+        webhookService.webhookProcess(webhookRequest, paymentKey);
+
+    }
+
+}

--- a/src/main/java/me/jaesung/simplepg/domain/dto/api/ApiCredentialRequest.java
+++ b/src/main/java/me/jaesung/simplepg/domain/dto/api/ApiCredentialRequest.java
@@ -4,7 +4,9 @@ import lombok.Data;
 
 @Data
 public class ApiCredentialRequest {
-    private String cliendId;
+    private String clientId;
     private String clientSecret;
     private String active;
+    private String clientName;
+    private String returnUrl;
 }

--- a/src/main/java/me/jaesung/simplepg/domain/dto/api/ApiCredentialResponse.java
+++ b/src/main/java/me/jaesung/simplepg/domain/dto/api/ApiCredentialResponse.java
@@ -1,19 +1,23 @@
 package me.jaesung.simplepg.domain.dto.api;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import me.jaesung.simplepg.domain.vo.api.ApiCredential;
 import me.jaesung.simplepg.domain.vo.api.ApiStatus;
 
 import java.time.LocalDateTime;
 
+@NoArgsConstructor
+@AllArgsConstructor
 @Data
 @Builder
 public class ApiCredentialResponse {
 
     private String clientId;
     private String clientSecret;
-    private String name;
+    private String clientName;
     private ApiStatus status;
     private LocalDateTime createdAt;
 
@@ -22,7 +26,7 @@ public class ApiCredentialResponse {
         return ApiCredentialResponse.builder()
                 .clientId(credential.getClientId())
                 .clientSecret(credential.getClientSecret())
-                .name(credential.getName())
+                .clientName(credential.getClientName())
                 .status(credential.getStatus())
                 .createdAt(credential.getCreatedAt())
                 .build();

--- a/src/main/java/me/jaesung/simplepg/domain/dto/payment/PaymentDTO.java
+++ b/src/main/java/me/jaesung/simplepg/domain/dto/payment/PaymentDTO.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 @Data @Builder
 public class PaymentDTO {
     private String paymentId;
+    private String clientId;
     private String paymentKey;
     private String orderNo;
     private BigDecimal amount;
@@ -25,5 +26,4 @@ public class PaymentDTO {
     private String transactionId;
     private LocalDateTime createdAt;
     private LocalDateTime approvedAt;
-
 }

--- a/src/main/java/me/jaesung/simplepg/domain/dto/payment/PaymentInfoDTO.java
+++ b/src/main/java/me/jaesung/simplepg/domain/dto/payment/PaymentInfoDTO.java
@@ -6,6 +6,7 @@ import lombok.Data;
 @Data @Builder
 public class PaymentInfoDTO {
     String paymentKey;
+    String clientId;
     String orderNo;
     String status;
     String amount;
@@ -17,6 +18,7 @@ public class PaymentInfoDTO {
     public static PaymentInfoDTO of(PaymentDTO paymentDTO) {
         return PaymentInfoDTO.builder()
                 .paymentKey(paymentDTO.getPaymentKey())
+                .clientId(paymentDTO.getClientId())
                 .orderNo(paymentDTO.getOrderNo())
                 .status(paymentDTO.getStatus().toString())
                 .amount(paymentDTO.getAmount().toString())

--- a/src/main/java/me/jaesung/simplepg/domain/dto/payment/PaymentRequest.java
+++ b/src/main/java/me/jaesung/simplepg/domain/dto/payment/PaymentRequest.java
@@ -8,6 +8,9 @@ import javax.validation.constraints.Pattern;
 @Data
 public class PaymentRequest {
 
+    @NotBlank(message = "가맹점 ID는 필수입니다")
+    private String clientId;
+
     @NotBlank(message = "주문 번호는 필수입니다")
     private String orderNo;
 

--- a/src/main/java/me/jaesung/simplepg/domain/dto/payment/PaymentResponse.java
+++ b/src/main/java/me/jaesung/simplepg/domain/dto/payment/PaymentResponse.java
@@ -8,13 +8,13 @@ import lombok.Data;
 @Builder
 public class PaymentResponse {
 
-    private String paymentId;
+    private String paymentKey;
     private String status;
     private String createdAt;
 
     public static PaymentResponse of(PaymentDTO paymentDTO) {
         return PaymentResponse.builder()
-                .paymentId(paymentDTO.getPaymentId())
+                .paymentKey(paymentDTO.getPaymentKey())
                 .status(paymentDTO.getStatus().toString())
                 .createdAt(paymentDTO.getCreatedAt().toString())
                 .build();

--- a/src/main/java/me/jaesung/simplepg/domain/dto/webhook/ExternalApiDTO.java
+++ b/src/main/java/me/jaesung/simplepg/domain/dto/webhook/ExternalApiDTO.java
@@ -1,0 +1,22 @@
+package me.jaesung.simplepg.domain.dto.webhook;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * PG -> 외부 결제
+ */
+@Data
+@Builder @AllArgsConstructor @NoArgsConstructor
+public class ExternalApiDTO {
+
+    private String paymentKey;
+    private String amount;
+    private String orderNo;
+    private String customerName;
+    private String methodCode;
+    private String successUrl;
+    private String failureUrl;
+}

--- a/src/main/java/me/jaesung/simplepg/domain/dto/webhook/WebhookRequest.java
+++ b/src/main/java/me/jaesung/simplepg/domain/dto/webhook/WebhookRequest.java
@@ -1,0 +1,14 @@
+package me.jaesung.simplepg.domain.dto.webhook;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data @Builder
+@AllArgsConstructor @NoArgsConstructor
+public class WebhookRequest {
+    private String transactionId;
+    private String paymentStatus;
+    private String approvedAt;
+}

--- a/src/main/java/me/jaesung/simplepg/domain/dto/webhook/WebhookResponse.java
+++ b/src/main/java/me/jaesung/simplepg/domain/dto/webhook/WebhookResponse.java
@@ -1,0 +1,18 @@
+package me.jaesung.simplepg.domain.dto.webhook;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * PG -> 가맹점
+ */
+@Data
+@Builder
+public class WebhookResponse {
+    private String clientId;
+    private String paymentKey;
+    private String amount;
+    private String orderNo;
+    private String customerName;
+    private String methodCode;
+}

--- a/src/main/java/me/jaesung/simplepg/domain/vo/api/ApiCredential.java
+++ b/src/main/java/me/jaesung/simplepg/domain/vo/api/ApiCredential.java
@@ -8,7 +8,8 @@ import java.time.LocalDateTime;
 public class ApiCredential {
     private String clientId;
     private String clientSecret;
-    private String name;
+    private String clientName;
     private ApiStatus status;
+    private String returnUrl;
     private LocalDateTime createdAt;
 }

--- a/src/main/java/me/jaesung/simplepg/domain/vo/payment/Payment.java
+++ b/src/main/java/me/jaesung/simplepg/domain/vo/payment/Payment.java
@@ -8,11 +8,12 @@ import java.time.LocalDateTime;
 @Getter
 public class Payment {
     private String paymentId;
+    private String clientId;
     private String paymentKey;
     private String orderNo;
     private BigDecimal amount;
     private PaymentStatus status;
-    private String methodCode;
+    private MethodCode methodCode;
     private String productName;
     private String customerName;
     private String transactionId;

--- a/src/main/java/me/jaesung/simplepg/mapper/ApiCredentialMapper.java
+++ b/src/main/java/me/jaesung/simplepg/mapper/ApiCredentialMapper.java
@@ -1,7 +1,12 @@
 package me.jaesung.simplepg.mapper;
 
+import me.jaesung.simplepg.domain.dto.api.ApiCredentialRequest;
 import me.jaesung.simplepg.domain.vo.api.ApiCredential;
 
+import java.util.Optional;
+
 public interface ApiCredentialMapper {
-    ApiCredential findByClientId(String clientId);
+    Optional<ApiCredential> findByClientId(String clientId);
+
+    void insertApiCredential(ApiCredentialRequest request);
 }

--- a/src/main/java/me/jaesung/simplepg/mapper/PaymentLogMapper.java
+++ b/src/main/java/me/jaesung/simplepg/mapper/PaymentLogMapper.java
@@ -2,7 +2,10 @@ package me.jaesung.simplepg.mapper;
 
 import me.jaesung.simplepg.domain.dto.payment.PaymentLogDTO;
 
+import java.util.Optional;
+
 public interface PaymentLogMapper {
 
     void insertPaymentLog(PaymentLogDTO paymentLogDTO);
+    Optional<PaymentLogDTO> findByPaymentId(String paymentId);
 }

--- a/src/main/java/me/jaesung/simplepg/mapper/PaymentMapper.java
+++ b/src/main/java/me/jaesung/simplepg/mapper/PaymentMapper.java
@@ -11,4 +11,6 @@ public interface PaymentMapper {
     boolean existsByOrderNo(String orderNo);
 
     Optional<PaymentDTO> findByPaymentKey(String paymentKey);
+
+    void updatePayment(PaymentDTO paymentDTO);
 }

--- a/src/main/java/me/jaesung/simplepg/service/api/ApiCredentialService.java
+++ b/src/main/java/me/jaesung/simplepg/service/api/ApiCredentialService.java
@@ -1,13 +1,16 @@
 package me.jaesung.simplepg.service.api;
 
 import lombok.extern.slf4j.Slf4j;
+import me.jaesung.simplepg.common.exception.ApiException;
+import me.jaesung.simplepg.domain.dto.api.ApiCredentialRequest;
 import me.jaesung.simplepg.domain.dto.api.ApiCredentialResponse;
 import me.jaesung.simplepg.domain.vo.api.ApiCredential;
 import me.jaesung.simplepg.domain.vo.api.ApiStatus;
 import me.jaesung.simplepg.mapper.ApiCredentialMapper;
 import org.springframework.stereotype.Service;
 
-@Service @Slf4j
+@Service
+@Slf4j
 public class ApiCredentialService {
     private final ApiCredentialMapper apiCredentialMapper;
 
@@ -15,13 +18,14 @@ public class ApiCredentialService {
         this.apiCredentialMapper = apiCredentialMapper;
     }
 
-    public boolean isValidApiCredential(String clientId){
+    public boolean isValidApiCredential(String clientId) {
         ApiCredentialResponse keyByClientId = findByClientId(clientId);
         return keyByClientId != null && keyByClientId.getStatus().equals(ApiStatus.ACTIVE);
     }
 
-    public ApiCredentialResponse findByClientId(String clientId){
-        ApiCredential keyByClientId = apiCredentialMapper.findByClientId(clientId);
+    public ApiCredentialResponse findByClientId(String clientId) {
+        ApiCredential keyByClientId = apiCredentialMapper.findByClientId(clientId)
+                .orElseThrow(() -> new ApiException.NotFoundException("clientID is not Found"));
         return ApiCredentialResponse.of(keyByClientId);
     }
 

--- a/src/main/java/me/jaesung/simplepg/service/webclient/WebClientService.java
+++ b/src/main/java/me/jaesung/simplepg/service/webclient/WebClientService.java
@@ -1,0 +1,109 @@
+package me.jaesung.simplepg.service.webclient;
+
+import lombok.extern.slf4j.Slf4j;
+import me.jaesung.simplepg.common.exception.ApiException;
+import me.jaesung.simplepg.common.exception.PaymentException;
+import me.jaesung.simplepg.common.util.HmacUtil;
+import me.jaesung.simplepg.domain.dto.api.ApiCredentialResponse;
+import me.jaesung.simplepg.domain.dto.payment.PaymentDTO;
+import me.jaesung.simplepg.domain.dto.webhook.ExternalApiDTO;
+import me.jaesung.simplepg.domain.dto.webhook.WebhookResponse;
+import me.jaesung.simplepg.domain.vo.api.ApiCredential;
+import me.jaesung.simplepg.mapper.ApiCredentialMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.LocalDateTime;
+
+@Service
+@Slf4j
+public class WebClientService {
+
+    private final String requestApiUrl;
+    private final String returnUrl;
+    private final WebClient webClient;
+    private final ApiCredentialMapper apiCredentialMapper;
+
+    public WebClientService(@Value("${api.request.url}") String requestApiUrl,
+                            @Value("${api.return.url}") String returnUrl,
+                            WebClient webClient, ApiCredentialMapper apiCredentialMapper) {
+        this.requestApiUrl = requestApiUrl;
+        this.returnUrl = returnUrl;
+        this.webClient = webClient;
+        this.apiCredentialMapper = apiCredentialMapper;
+    }
+
+    public void sendRequest(PaymentDTO paymentDTO) {
+
+        ExternalApiDTO externalApiDTO = ExternalApiDTO.builder()
+                .paymentKey(paymentDTO.getPaymentKey())
+                .amount(paymentDTO.getAmount().toString())
+                .orderNo(paymentDTO.getOrderNo())
+                .customerName(paymentDTO.getCustomerName())
+                .methodCode(paymentDTO.getMethodCode().toString())
+                .successUrl(returnUrl + "/" + paymentDTO.getPaymentKey() + "/success")
+                .failureUrl(returnUrl + "/" + paymentDTO.getPaymentKey() + "/failure")
+                .build();
+
+        webClient.post()
+                .uri(requestApiUrl)
+                .bodyValue(externalApiDTO)
+                .retrieve()
+                .bodyToMono(String.class)
+                .subscribe(
+                        null,
+                        error -> {
+                            throw new PaymentException.ExternalPaymentException("외부 결제 서버로 요청 실패");
+                        }
+                );
+    }
+
+    public void sendResponse(WebhookResponse webhookResponse) throws Exception {
+
+        String data = plusBody(webhookResponse);
+        String clientId = webhookResponse.getClientId();
+
+        ApiCredential apiCredential = apiCredentialMapper.findByClientId(clientId)
+                .orElseThrow(() -> new ApiException.NotFoundException("해당 clientId가 존재하지 않습니다"));
+        String clientSecret = apiCredential.getClientSecret();
+
+        ApiCredentialResponse apiCredentialResponse = ApiCredentialResponse.of(apiCredential);
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add("X-CLIENT-ID", clientId);
+        httpHeaders.add("X-TIMESTAMP", LocalDateTime.now().toString());
+        httpHeaders.add("X-SIGNATURE", HmacUtil.generateSignature(data,clientSecret));
+
+        webClient.post()
+                .uri(apiCredential.getReturnUrl())
+                .headers(h -> h.addAll(httpHeaders))
+                .bodyValue(apiCredentialResponse)
+                .retrieve()
+                .bodyToMono(ApiCredentialResponse.class)
+                .block();
+
+    }
+
+    private String plusBody(WebhookResponse webhookResponse) {
+        try {
+            if (webhookResponse == null) {
+                throw new NullPointerException("webhookResponse가 null입니다");
+            }
+
+            StringBuffer sb = new StringBuffer();
+            sb.append(webhookResponse.getClientId());
+            sb.append(webhookResponse.getPaymentKey());
+            sb.append(webhookResponse.getAmount());
+            sb.append(webhookResponse.getOrderNo());
+            sb.append(webhookResponse.getCustomerName());
+            sb.append(webhookResponse.getMethodCode());
+
+            return sb.toString();
+
+        } catch (NullPointerException e) {
+            log.error("webhook 수신 후 바디 생성 중 예외 발생 내용:{}", e.getMessage());
+            throw new PaymentException.ProcessingException("webhook 수신 후 바디 생성 중 예외 발생");
+        }
+    }
+}

--- a/src/main/java/me/jaesung/simplepg/service/webhook/WebhookFailedService.java
+++ b/src/main/java/me/jaesung/simplepg/service/webhook/WebhookFailedService.java
@@ -1,0 +1,51 @@
+package me.jaesung.simplepg.service.webhook;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.jaesung.simplepg.common.exception.PaymentException;
+import me.jaesung.simplepg.common.util.DateTimeUtil;
+import me.jaesung.simplepg.domain.dto.payment.PaymentDTO;
+import me.jaesung.simplepg.domain.dto.payment.PaymentLogDTO;
+import me.jaesung.simplepg.domain.dto.webhook.WebhookRequest;
+import me.jaesung.simplepg.domain.dto.webhook.WebhookResponse;
+import me.jaesung.simplepg.domain.vo.payment.PaymentLogAction;
+import me.jaesung.simplepg.domain.vo.payment.PaymentStatus;
+import me.jaesung.simplepg.mapper.PaymentLogMapper;
+import me.jaesung.simplepg.mapper.PaymentMapper;
+import me.jaesung.simplepg.service.webclient.WebClientService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@Slf4j
+public class WebhookFailedService extends WebhookServiceImpl {
+
+    public WebhookFailedService(PaymentMapper paymentMapper, PaymentLogMapper paymentLogMapper, WebClientService webClientService) {
+        super(paymentMapper, paymentLogMapper, webClientService);
+    }
+
+    @Override
+    protected void validatePayment(PaymentDTO paymentDTO, WebhookRequest webhookRequest) {
+        if (!webhookRequest.getPaymentStatus().equals(PaymentStatus.FAILED.toString())) {
+            throw new PaymentException.WebhookProcessingException("외부 Status 정보가 서버의 정보와 다릅니다");
+        }
+    }
+
+    @Override
+    protected void processPaymentStatus(PaymentDTO paymentDTO, WebhookRequest webhookRequest) {
+        paymentDTO.setStatus(PaymentStatus.FAILED);
+        paymentDTO.setTransactionId(webhookRequest.getTransactionId());
+
+        PaymentLogDTO paymentLogDTO = PaymentLogDTO.builder()
+                .paymentId(paymentDTO.getPaymentId())
+                .action(PaymentLogAction.FAIL)
+                .status(PaymentStatus.FAILED)
+                .details("실패한 결제 내역입니다(실패 일시:" + LocalDateTime.now())
+                .build();
+
+        paymentMapper.updatePayment(paymentDTO);
+        paymentLogMapper.insertPaymentLog(paymentLogDTO);
+    }
+}

--- a/src/main/java/me/jaesung/simplepg/service/webhook/WebhookService.java
+++ b/src/main/java/me/jaesung/simplepg/service/webhook/WebhookService.java
@@ -1,0 +1,8 @@
+package me.jaesung.simplepg.service.webhook;
+
+import me.jaesung.simplepg.domain.dto.webhook.WebhookRequest;
+import me.jaesung.simplepg.domain.dto.webhook.WebhookResponse;
+
+public interface WebhookService {
+    void webhookProcess(WebhookRequest webhookRequest, String paymentKey);
+}

--- a/src/main/java/me/jaesung/simplepg/service/webhook/WebhookServiceFactory.java
+++ b/src/main/java/me/jaesung/simplepg/service/webhook/WebhookServiceFactory.java
@@ -1,0 +1,23 @@
+package me.jaesung.simplepg.service.webhook;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WebhookServiceFactory {
+
+    private final WebhookService webhookSuccessService;
+    private final WebhookService webhookFailedService;
+
+    /**
+     * 웹훅 상태에 따라 적절한 서비스를 반환
+     */
+    public WebhookService getWebhookService(String webhookStatus) {
+        if ("failure".equals(webhookStatus)) {
+            return webhookFailedService;
+        } else {
+            return webhookSuccessService;
+        }
+    }
+}

--- a/src/main/java/me/jaesung/simplepg/service/webhook/WebhookServiceImpl.java
+++ b/src/main/java/me/jaesung/simplepg/service/webhook/WebhookServiceImpl.java
@@ -1,0 +1,72 @@
+package me.jaesung.simplepg.service.webhook;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.jaesung.simplepg.common.exception.PaymentException;
+import me.jaesung.simplepg.common.util.DateTimeUtil;
+import me.jaesung.simplepg.domain.dto.payment.PaymentDTO;
+import me.jaesung.simplepg.domain.dto.payment.PaymentLogDTO;
+import me.jaesung.simplepg.domain.dto.webhook.WebhookRequest;
+import me.jaesung.simplepg.domain.dto.webhook.WebhookResponse;
+import me.jaesung.simplepg.domain.vo.payment.PaymentLogAction;
+import me.jaesung.simplepg.domain.vo.payment.PaymentStatus;
+import me.jaesung.simplepg.mapper.PaymentLogMapper;
+import me.jaesung.simplepg.mapper.PaymentMapper;
+import me.jaesung.simplepg.service.webclient.WebClientService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public abstract class WebhookServiceImpl implements WebhookService {
+
+    protected final PaymentMapper paymentMapper;
+    protected final PaymentLogMapper paymentLogMapper;
+    protected final WebClientService webClientService;
+
+    @Override
+    @Transactional
+    public void webhookProcess(WebhookRequest webhookRequest, String paymentKey) {
+        try {
+
+            PaymentDTO paymentDTO = paymentMapper.findByPaymentKey(paymentKey)
+                    .orElseThrow(() -> new PaymentException.InvalidPaymentRequestException("결제 정보를 찾을 수 없습니다"));
+
+            if (!paymentDTO.getStatus().toString().equals("READY")) {
+                throw new PaymentException.InvalidPaymentRequestException("이미 처리된 결제 내역 입니다");
+            }
+
+            validatePayment(paymentDTO, webhookRequest);
+
+            processPaymentStatus(paymentDTO, webhookRequest);
+
+            WebhookResponse webhookResponse = WebhookResponse.builder()
+                    .clientId(paymentDTO.getClientId())
+                    .paymentKey(paymentKey)
+                    .amount(paymentDTO.getAmount().toString())
+                    .orderNo(paymentDTO.getOrderNo())
+                    .customerName(paymentDTO.getCustomerName())
+                    .methodCode(paymentDTO.getMethodCode().toString())
+                    .build();
+
+            webClientService.sendResponse(webhookResponse);
+
+        } catch (Exception e) {
+            log.error("웹훅 처리 실패: paymentKey={}, 원인={}", paymentKey, e.getMessage(), e);
+            throw new PaymentException.WebhookProcessingException("웹훅 수신 데이터 처리 실패");
+        }
+    }
+
+    /**
+     * 결제 정보와 웹훅 요청 검증
+     */
+    protected abstract void validatePayment(PaymentDTO paymentDTO, WebhookRequest webhookRequest);
+
+    /**
+     * 결제 상태 처리
+     */
+    protected abstract void processPaymentStatus(PaymentDTO paymentDTO, WebhookRequest webhookRequest);
+}

--- a/src/main/java/me/jaesung/simplepg/service/webhook/WebhookSuccessService.java
+++ b/src/main/java/me/jaesung/simplepg/service/webhook/WebhookSuccessService.java
@@ -1,0 +1,53 @@
+package me.jaesung.simplepg.service.webhook;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.jaesung.simplepg.common.exception.PaymentException;
+import me.jaesung.simplepg.common.util.DateTimeUtil;
+import me.jaesung.simplepg.domain.dto.payment.PaymentDTO;
+import me.jaesung.simplepg.domain.dto.payment.PaymentLogDTO;
+import me.jaesung.simplepg.domain.dto.webhook.WebhookRequest;
+import me.jaesung.simplepg.domain.dto.webhook.WebhookResponse;
+import me.jaesung.simplepg.domain.vo.payment.PaymentLogAction;
+import me.jaesung.simplepg.domain.vo.payment.PaymentStatus;
+import me.jaesung.simplepg.mapper.PaymentLogMapper;
+import me.jaesung.simplepg.mapper.PaymentMapper;
+import me.jaesung.simplepg.service.webclient.WebClientService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+
+@Service
+@Slf4j
+public class WebhookSuccessService extends WebhookServiceImpl {
+
+    public WebhookSuccessService(PaymentMapper paymentMapper, PaymentLogMapper paymentLogMapper, WebClientService webClientService) {
+        super(paymentMapper, paymentLogMapper, webClientService);
+    }
+
+    @Override
+    protected void validatePayment(PaymentDTO paymentDTO, WebhookRequest webhookRequest) {
+        if (!webhookRequest.getPaymentStatus().equals(PaymentStatus.APPROVED.name().toString())) {
+            throw new PaymentException.WebhookProcessingException("외부 Status 정보가 서버의 정보와 다릅니다");
+        }
+    }
+
+    @Override
+    protected void processPaymentStatus(PaymentDTO paymentDTO, WebhookRequest webhookRequest) {
+        paymentDTO.setStatus(PaymentStatus.APPROVED);
+        paymentDTO.setApprovedAt(DateTimeUtil.parseIso(webhookRequest.getApprovedAt()));
+        paymentDTO.setTransactionId(webhookRequest.getTransactionId());
+
+        PaymentLogDTO paymentLogDTO = PaymentLogDTO.builder()
+                .paymentId(paymentDTO.getPaymentId())
+                .action(PaymentLogAction.APPROVE)
+                .status(PaymentStatus.APPROVED)
+                .details("승인된 결제 내역입니다(승인 일시:" + LocalDateTime.now())
+                .build();
+
+        paymentMapper.updatePayment(paymentDTO);
+        paymentLogMapper.insertPaymentLog(paymentLogDTO);
+    }
+}

--- a/src/main/resources/me/jaesung/simplepg/mapper/ApiCredentialMapper.xml
+++ b/src/main/resources/me/jaesung/simplepg/mapper/ApiCredentialMapper.xml
@@ -3,10 +3,15 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="me.jaesung.simplepg.mapper.ApiCredentialMapper">
+
     <select id="findByClientId" resultType="me.jaesung.simplepg.domain.vo.api.ApiCredential">
-        SELECT client_id, client_secret, name, status, created_at
+        SELECT client_id, client_secret, client_name, status, return_url, created_at
         FROM api_credential
         WHERE client_id = #{clientId}
     </select>
+
+    <insert id="insertApiCredential" parameterType="me.jaesung.simplepg.domain.dto.api.ApiCredentialRequest">
+        INSERT INTO (client_id, client_secret, client_name, status, return_url) VALUES(#{clientId},#{clientSecret},#{clientName},#{active},#{returnUrl})
+    </insert>
 
 </mapper>

--- a/src/main/resources/me/jaesung/simplepg/mapper/PaymentLogMapper.xml
+++ b/src/main/resources/me/jaesung/simplepg/mapper/PaymentLogMapper.xml
@@ -5,9 +5,8 @@
 <mapper namespace="me.jaesung.simplepg.mapper.PaymentLogMapper">
 
     <insert id="insertPaymentLog" parameterType="me.jaesung.simplepg.domain.dto.payment.PaymentLogDTO">
-        INSERT INTO PAYMENT_LOG (payment_id, action, status, details, created_at)
-        VALUES (#{paymentId},#{action},#{status},#{details},#{createdAt})
+        INSERT INTO PAYMENT_LOG (payment_id, action, status, details)
+        VALUES (#{paymentId}, #{action}, #{status}, #{details})
     </insert>
-
 
 </mapper>

--- a/src/main/resources/me/jaesung/simplepg/mapper/PaymentMapper.xml
+++ b/src/main/resources/me/jaesung/simplepg/mapper/PaymentMapper.xml
@@ -5,8 +5,10 @@
 <mapper namespace="me.jaesung.simplepg.mapper.PaymentMapper">
 
     <insert id="insertPayment" parameterType="me.jaesung.simplepg.domain.dto.payment.PaymentDTO">
-        INSERT INTO PAYMENT (payment_id, payment_key, order_no, amount, status, method_code, product_name, customer_name, created_at)
-        VALUES(#{paymentId},#{paymentKey},#{orderNo},#{amount},#{status},#{methodCode},#{productName},#{customerName},#{createdAt});
+        INSERT INTO PAYMENT (payment_id, payment_key, client_id, order_no, amount, status, method_code, product_name,
+                             customer_name, created_at)
+        VALUES (#{paymentId}, #{paymentKey}, #{clientId}, #{orderNo}, #{amount}, #{status}, #{methodCode},
+                #{productName}, #{customerName}, #{createdAt});
     </insert>
 
     <select id="existsByOrderNo" parameterType="string" resultType="boolean">
@@ -16,5 +18,10 @@
     <select id="findByPaymentKey" parameterType="string" resultType="me.jaesung.simplepg.domain.dto.payment.PaymentDTO">
         SELECT * FROM PAYMENT WHERE payment_key = #{paymentKey}
     </select>
+
+    <update id="updatePayment" parameterType="me.jaesung.simplepg.domain.dto.payment.PaymentDTO">
+        UPDATE PAYMENT SET status = #{status}, approved_at = #{approvedAt}, transaction_id = #{transactionId} WHERE payment_id = #{paymentId}
+    </update>
+
 
 </mapper>

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -8,5 +8,10 @@
         <setting name="mapUnderscoreToCamelCase" value="true"/>
         <setting name="logImpl" value="STDOUT_LOGGING"/>
     </settings>
+
+    <typeHandlers>
+        <typeHandler handler="org.apache.ibatis.type.EnumTypeHandler" javaType="java.lang.Enum"/>
+    </typeHandlers>
+
 </configuration>
 


### PR DESCRIPTION
# ✨ PG 서비스 웹훅 처리 및 결제 결과 알림 기능 구현

## 🔎 PR 개요
외부 결제 서버로부터의 웹훅 수신 처리 및 상점 서버로의 결제 결과 알림 전송 기능을 구현했습니다. 구체적으로는 외부 결제 서버로 결제 요청을 보낸 후 결제 결과를 웹훅으로 수신하고, 이를 다시 상점 서버로 알리는 방식으로 설계하였습니다.

## 🔗 연관된 이슈
- closed #9 - PG 서버의 웹훅 수신 및 상점 서버 알림

## 🔧 주요 변경 사항
* 외부 결제 서버의 웹훅 수신 엔드포인트 구현 (/mock/request)
 -> 새로운 스레드를 생성해서 1초 후에 웹훅(Webhook) 요청 (임의의 MockController)
 ```Java
    @PostMapping("/request")
    public ResponseEntity<String> handleMockData(@RequestBody ExternalApiDTO externalApiDTO) {

        String transactionId = UUID.randomUUID().toString();

        WebhookRequest webhookRequest = WebhookRequest.builder()
                .transactionId(transactionId)
                .paymentStatus("APPROVED")
                .approvedAt(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME))
                .build();

        new Thread(() -> {
            try {
                Thread.sleep(1000);

                webClient.post()
                        .uri("/api/payment/webhook")
                        .bodyValue(webhookRequest)
                        .retrieve()
                        .bodyToMono(String.class);
                
            } catch (InterruptedException e) {
                Thread.currentThread().interrupt();
                log.error("웹훅 전송 중 인터럽트 발생", e);
            }
        }).start();

        log.info("Mock 서버가 트랜잭션 전송 transactionID: {}", transactionId);
        return ResponseEntity.ok("Payment Request From MockController transactionId: " + transactionId);
    }
 ```
* 수신된 웹훅 데이터를 처리하는 서비스 로직 개선
* 웹훅으로 부터 수신된 URL에 따라 적절한 서비스 반환 로직
 ```Java
 @Component
@RequiredArgsConstructor
public class WebhookServiceFactory {

    private final WebhookService webhookSuccessService;
    private final WebhookService webhookFailedService;

    /**
     * 웹훅 상태에 따라 적절한 서비스를 반환
     */
    public WebhookService getWebhookService(String webhookStatus) {
        if ("failure".equals(webhookStatus)) {
            return webhookFailedService;
        } else {
            return webhookSuccessService;
        }
    }
}
 ```
* 상점 서버로 결제 결과 알림 전송 기능 구현 (WebClient)
* HMAC-SHA256 서명을 통한 알림 데이터 보안 처리
 
## 🏆 기술적 개선 사항
* 비동기 웹훅 처리를 통한 시스템 안정성 향상
* 웹훅 처리 결과 로깅을 통한 모니터링 용이성 제공
* HMAC 기반 보안 처리로 데이터 무결성 보장

## 🧪 테스트 케이스
* 외부 결제 서버로부터 성공 웹훅 수신 및 처리 테스트
* 외부 결제 서버로부터 실패 웹훅 수신 및 처리 테스트
* 상점 서버로 웹훅 전송 및 성공 확인 테스트
* 상점 서버 웹훅 전송 실패 시 재시도 로직 테스트
* HMAC 서명 검증 테스트

## 📂 변경된 디렉토리 구조
```Java
src/main/java/me/jaesung/simplepg/
├── controller/
│   └── webhook/
│       └──  WebhookController.java
│   └── mock/
│       └──  MockController.java
├── service/
│   ├── webclient/
│   │   └── WebClientService.java
│   └── webhook/
│       ├── WebhookService.java
│       ├── WebhookServiceImpl.java
│       └── WebhookResultProcessor.java 
└── common/
```
## 📝 참고 사항
* HMAC 서명은 클라이언트 ID, 결제 키, 금액, 주문번호를 포함하여 생성
* 향후 Prometheus 기반 모니터링 통합을 위한 기반 마련

## 🚀 향후 개선 방향
* 웹훅 처리 결과를 DB에 저장하여 실패한 웹훅에 대한 수동 복구 기능 구현
* 웹훅 재시도 로직 구현 (Spring Retry 또는 Resilience4j와 같은 라이브러리 사용 예정)
* 웹훅 전송 실패 시 재시도 간격은 exponential backoff 방식 적용 (1초, 3초, 9초)
* 결제 상태 변경에 대한 이벤트 발행 검토