### PR TITLE
Fix: PaymentKey, OrderNo 조회 시 배타적 락 적용

### DIFF
--- a/src/main/java/me/jaesung/simplepg/mapper/PaymentMapper.java
+++ b/src/main/java/me/jaesung/simplepg/mapper/PaymentMapper.java
@@ -1,7 +1,6 @@
 package me.jaesung.simplepg.mapper;
 
 import me.jaesung.simplepg.domain.dto.payment.PaymentDTO;
-import me.jaesung.simplepg.domain.vo.payment.Payment;
 
 import java.util.Optional;
 
@@ -10,7 +9,10 @@ public interface PaymentMapper {
 
     boolean existsByOrderNo(String orderNo);
 
-    Optional<PaymentDTO> findByPaymentKey(String paymentKey);
+    boolean lockByOrderNo(String orderNo);
+
+    Optional<PaymentDTO> findByPaymentKeyWithLock(String paymentKey);
 
     void updatePayment(PaymentDTO paymentDTO);
+
 }

--- a/src/main/java/me/jaesung/simplepg/service/payment/PaymentService.java
+++ b/src/main/java/me/jaesung/simplepg/service/payment/PaymentService.java
@@ -32,6 +32,8 @@ public class PaymentService {
 
         validateClientId(request);
 
+        paymentMapper.lockByOrderNo(request.getOrderNo());
+
         validateOrderNo(request);
 
         BigDecimal amountBD = validateAmount(request);
@@ -60,7 +62,7 @@ public class PaymentService {
 
     @Transactional
     public PaymentInfoDTO getPaymentStatus(String paymentKey) {
-        PaymentDTO paymentDTO = paymentMapper.findByPaymentKey(paymentKey)
+        PaymentDTO paymentDTO = paymentMapper.findByPaymentKeyWithLock(paymentKey)
                 .orElseThrow(() -> new PaymentException.InvalidPaymentRequestException("결제 정보를 찾을 수 없습니다:" + paymentKey));
 
         log.info("결제 상태 체크: {}, 현재 상태: {}", paymentKey, paymentDTO.getStatus().toString());

--- a/src/main/java/me/jaesung/simplepg/service/webhook/WebhookServiceImpl.java
+++ b/src/main/java/me/jaesung/simplepg/service/webhook/WebhookServiceImpl.java
@@ -3,20 +3,15 @@ package me.jaesung.simplepg.service.webhook;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.jaesung.simplepg.common.exception.PaymentException;
-import me.jaesung.simplepg.common.util.DateTimeUtil;
 import me.jaesung.simplepg.domain.dto.payment.PaymentDTO;
-import me.jaesung.simplepg.domain.dto.payment.PaymentLogDTO;
 import me.jaesung.simplepg.domain.dto.webhook.WebhookRequest;
 import me.jaesung.simplepg.domain.dto.webhook.WebhookResponse;
-import me.jaesung.simplepg.domain.vo.payment.PaymentLogAction;
 import me.jaesung.simplepg.domain.vo.payment.PaymentStatus;
 import me.jaesung.simplepg.mapper.PaymentLogMapper;
 import me.jaesung.simplepg.mapper.PaymentMapper;
 import me.jaesung.simplepg.service.webclient.WebClientService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
 
 @Service
 @Slf4j
@@ -32,10 +27,10 @@ public abstract class WebhookServiceImpl implements WebhookService {
     public void webhookProcess(WebhookRequest webhookRequest, String paymentKey) {
         try {
 
-            PaymentDTO paymentDTO = paymentMapper.findByPaymentKey(paymentKey)
+            PaymentDTO paymentDTO = paymentMapper.findByPaymentKeyWithLock(paymentKey)
                     .orElseThrow(() -> new PaymentException.InvalidPaymentRequestException("결제 정보를 찾을 수 없습니다"));
 
-            if (!paymentDTO.getStatus().toString().equals("READY")) {
+            if (paymentDTO.getStatus() == PaymentStatus.READY) {
                 throw new PaymentException.InvalidPaymentRequestException("이미 처리된 결제 내역 입니다");
             }
 

--- a/src/main/resources/me/jaesung/simplepg/mapper/PaymentMapper.xml
+++ b/src/main/resources/me/jaesung/simplepg/mapper/PaymentMapper.xml
@@ -15,13 +15,17 @@
         SELECT EXISTS(SELECT 1 FROM PAYMENT WHERE order_no = #{orderNo})
     </select>
 
-    <select id="findByPaymentKey" parameterType="string" resultType="me.jaesung.simplepg.domain.dto.payment.PaymentDTO">
-        SELECT * FROM PAYMENT WHERE payment_key = #{paymentKey}
+    <select id="findByPaymentKeyWithLock" parameterType="string" resultType="me.jaesung.simplepg.domain.dto.payment.PaymentDTO">
+        SELECT * FROM PAYMENT WHERE payment_key = #{paymentKey} FOR UPDATE;
     </select>
 
     <update id="updatePayment" parameterType="me.jaesung.simplepg.domain.dto.payment.PaymentDTO">
         UPDATE PAYMENT SET status = #{status}, approved_at = #{approvedAt}, transaction_id = #{transactionId} WHERE payment_id = #{paymentId}
     </update>
+
+    <select id="lockByOrderNo" parameterType="string" resultType="boolean">
+        SELECT 1 FROM PAYMENT WHERE order_no = #{orderNo} FOR UPDATE
+    </select>
 
 
 </mapper>


### PR DESCRIPTION
# ✨ 결제 시스템 웹훅 처리 시 동시성 제어 로직 

## 🔎 PR 개요
결제 시스템의 결제 생성 및 웹훅 처리 과정에서 발생할 수 있는 동시성 이슈를 해결하기 위해 데이터베이스 레벨의 비관적 락 로직을 구현하였습니다. `payment_key`와 `order_no`에 대한 비관적 락(FOR UPDATE)를 활용하여 데이터 일관성과 무결성을 보장하였으며, 여러 스레드에서 같은 결제 데이터 접근, 웹훅 요청의 중복 처리를 방지하였습니다.

## 🔗 연관된 이슈
- closed #11 - 결제 및 로그 생성 동시성 제어 로직 

## 🔧 주요 변경 사항
 - **데이터베이스 레벨 동시성 제어**
   - PaymentMapper에 비관적 락(FOR UPDATE)을 적용한 findByPaymentKeyWithLock 메서드 추가
   -> 웹훅 처리 시 동일 payment_key에 대한 동시 접근 방지
   ```Java
     // PaymentMapper.xml
    <select id="findByPaymentKeyWithLock" parameterType="string" 
     resultType="me.jaesung.simplepg.domain.dto.payment.PaymentDTO">
        SELECT * FROM PAYMENT WHERE payment_key = #{paymentKey} FOR UPDATE;
    </select>

    // PaymentService.java
    PaymentDTO paymentDTO = paymentMapper.findByPaymentKeyWithLock(paymentKey)
                .orElseThrow(() -> new PaymentException.InvalidPaymentRequestException("결제 정보를 찾을 수 없습니다:" + 
    paymentKey));
   ```
   - 기존의 OrderNo 검증 유직은 유지하면서, 동시성 처리
   ```Java
    // PaymentMapper.xml
   <select id="lockByOrderNo" parameterType="string" resultType="boolean">
        SELECT 1 FROM PAYMENT WHERE order_no = #{orderNo} FOR UPDATE
    </select>
   
   // PaymentService.java
    validateClientId(request);

    paymentMapper.lockByOrderNo(request.getOrderNo());

    validateOrderNo(request);
   ```
 - **애플리케이션 레벨 동시성 제어**
    - 현재 로직에서 `payment_key`에 대한 비관적 락을 데이터베이스 레벨에서 적용하였으므로 이하의 **트랜잭션 범위 내에서 모든 작업이 안전하게 수행**될 것이라고 생각하여 기존의 이슈에서 제기했던 createdAt을 활용한 낙관적 락은 도입하지 않았습니다.
    
- 기존 Enum 타입을 문자열로 변환해 비교하던 로직을 Enum 상수와 직접 비교하는 방식으로 변경하였습니다.
   ```Java
   if (paymentDTO.getStatus() == PaymentStatus.READY) {
   ``` 
 
## 🏆 기술적 개선 사항
* `findByPaymentKeyWithLock`과 `lockByOrderNo를` 통해 `payment_key`와 `order_no`에 대한 동시 접근 제어
* 트랜잭션 내 락 유지로 웹훅 처리 및 결제 생성의 데이터 무결성 보장


## 🧪 테스트 케이스
* 동시성 제어 테스트

## 📂 변경된 디렉토리 구조
```Java
src/main/java/com/pg/payment/
├── controller/
│   └── WebhookController.java
├── dto/
│   ├── PaymentDTO.java
│   └── WebhookRequest.java
├── service/
│   ├── WebhookServiceImpl.java
│   └── WebhookFailedService.java
├── mapper/
│   ├── PaymentMapper.java // findByPaymentKeyWithLock, lockByOrderNo
│   └── PaymentLogMapper.java
├── model/
│   └── PaymentStatus.java

```
## 📝 참고 사항
* 결제 상태는 `READY`, `APPROVED`, `COMPLETED`, `CANCELED`, `FAILED`로 정의
* 비관적 락은 PAYMENT 테이블의 payment_key 및 order_no에 적용되며, 트랜잭션 종료 시 해제
* 낙관적 락은 비관적 락(findByPaymentKeyWithLock)과 @Transactional로 충분히 동시성 제어가 가능하므로 제외

## 🚀 향후 개선 방향
* 웹훅 처리 결과를 DB에 저장하여 실패한 웹훅에 대한 수동 복구 기능 구현
* 웹훅 재시도 로직 구현 (Spring Retry 또는 Resilience4j와 같은 라이브러리 사용 예정)
* 웹훅 전송 실패 시 재시도 간격은 exponential backoff 방식 적용 (1초, 3초, 9초)
* 결제 상태 변경에 대한 이벤트 발행 검토