### PR TITLE
Feat: 결제 취소 및 완료 처리

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="PROJECT" charset="UTF-8" />
+  </component>
+</project>

--- a/src/main/java/me/jaesung/simplepg/controller/payment/PaymentController.java
+++ b/src/main/java/me/jaesung/simplepg/controller/payment/PaymentController.java
@@ -19,14 +19,28 @@ public class PaymentController {
 
     @PostMapping
     public ResponseEntity<PaymentResponse> createPayment(@RequestBody @Valid PaymentRequest paymentRequest) {
-        PaymentResponse paymentAndLog = paymentService.createPaymentAndLog(paymentRequest);
-        return ResponseEntity.ok(paymentAndLog);
+        PaymentResponse paymentResponse = paymentService.createPaymentAndLog(paymentRequest);
+        return ResponseEntity.ok(paymentResponse);
     }
 
     @GetMapping("/{paymentKey}")
     public ResponseEntity<PaymentInfoDTO> getPaymentStatus(@PathVariable String paymentKey) {
         PaymentInfoDTO paymentStatus = paymentService.getPaymentStatus(paymentKey);
         return ResponseEntity.ok(paymentStatus);
+    }
+
+    @PostMapping("/{paymentKey}/cancel")
+    public ResponseEntity<PaymentInfoDTO> cancelPayment(
+            @PathVariable String paymentKey,
+            @RequestParam(required = false) String cancelReason) {
+        PaymentInfoDTO canceledPayment = paymentService.cancelPayment(paymentKey, cancelReason);
+        return ResponseEntity.ok(canceledPayment);
+    }
+
+    @PostMapping("/{paymentKey}/complete")
+    public ResponseEntity<PaymentInfoDTO> completePayment(@PathVariable String paymentKey) {
+        PaymentInfoDTO completedPayment = paymentService.completePayment(paymentKey);
+        return ResponseEntity.ok(completedPayment);
     }
 
 }

--- a/src/main/java/me/jaesung/simplepg/domain/dto/webhook/ExternalApiDTO.java
+++ b/src/main/java/me/jaesung/simplepg/domain/dto/webhook/ExternalApiDTO.java
@@ -19,4 +19,6 @@ public class ExternalApiDTO {
     private String methodCode;
     private String successUrl;
     private String failureUrl;
+    private String transactionId;
+    private String cancelReason;
 }


### PR DESCRIPTION
# ✨ 결제 취소 및 완료 처리

## 🔎 PR 개요
결제 상태 유효성 검증 메서드를 추가하였습니다. 
결제 생명주기 중 상태 완료 및 취소 상황에 대한 로직을 구현하였습니다.

## 🔗 연관된 이슈
- #13 

## 🔧 주요 변경 사항
- **결제 상태 전이 로직 구현**
   - 각각의 결제 상태간 전이 시 유효성을 검증하는 메서드를 작성하였습니다.
   - 허용된 상태 전이(예: READY → APPROVED, APPROVED → COMPLETED, APPROVED → CANCELED)만 가능하도록 제한 및 검즈합니다.
   ```java
    /**
     * 결제 상태 전이 유효성 검증 메소드
     * 허용된 상태 전이만 가능하도록 제한
     */
    private void validatePaymentStatusTransition(PaymentStatus currentStatus, PaymentStatus targetStatus) {
        boolean isValid = false;
        
        switch (currentStatus) {
            case READY:
                isValid = targetStatus == PaymentStatus.APPROVED ||
                          targetStatus == PaymentStatus.FAILED ||
                          targetStatus == PaymentStatus.CANCELED;
                break;
            case APPROVED:
                isValid = targetStatus == PaymentStatus.COMPLETED ||
                          targetStatus == PaymentStatus.CANCELED;
                break;
            case COMPLETED:
                isValid = targetStatus == PaymentStatus.CANCELED;
                break;
            case FAILED:
            case CANCELED:
                isValid = false;
                break;
        }
        
        if (!isValid) {
            throw new PaymentException.InvalidPaymentRequestException(
                    String.format("유효하지 않은 상태 전이입니다: %s → %s", currentStatus, targetStatus));
        }
    }
   ```
- **결제 취소 기능 구현**
   - 결제 취소 요청을 처리하는 동기 방식 로직을 구현했습니다. `webClientService.sendCancelRequest`를 통해 외부 결제 시스템(예: PG사)과 통신하며, 성공 시 결제 상태를 CANCELED로 전이합니다. 
   -  현재 로그 생성 로직은 결제 처리와 동일 트랜잭션에 포함되어 있으나, 분리 예정에 있습니다.
   ```java
       @Transactional
    public PaymentInfoDTO cancelPayment(String paymentKey, String cancelReason) {

        PaymentDTO paymentDTO = paymentMapper.findByPaymentKeyWithLock(paymentKey)
                .orElseThrow(() -> new PaymentException.InvalidPaymentRequestException("결제 정보를 찾을 수 없습니다:" + paymentKey));

        validatePaymentStatusTransition(paymentDTO.getStatus(), PaymentStatus.CANCELED);

        try {
            webClientService.sendCancelRequest(paymentDTO, cancelReason);

            paymentDTO.setStatus(PaymentStatus.CANCELED);

            PaymentLogDTO paymentLogDTO = PaymentLogDTO.builder()
                    .paymentId(paymentDTO.getPaymentId())
                    .action(PaymentLogAction.CANCEL)
                    .status(PaymentStatus.CANCELED)
                    .details("결제 취소 처리되었습니다. " + (cancelReason != null ? "사유: " + cancelReason : ""))
                    .createdAt(LocalDateTime.now())
                    .build();

            paymentMapper.updatePayment(paymentDTO);
            paymentLogMapper.insertPaymentLog(paymentLogDTO);

            log.info("결제 취소 성공: paymentKey={}, 취소사유={}", paymentKey, cancelReason);

            return PaymentInfoDTO.of(paymentDTO);
        } catch (Exception e) {
            log.error("결제 취소 중 오류 발생: {}", e.getMessage(), e);
            throw new PaymentException.ProcessingException("결제 취소 처리 중 오류가 발생했습니다");
        }
    }

   ```
- **결제 완료 처리 기능 구현**
   - 결제 완료의 경우 가맹점 서버 측의 수신 처리까지 완료되면 APPROVE 상태에서 COMPLETED 상태로 변경하는 로직에 사용합니다.
   - 웹 훅 수신시 한꺼번에 처리하는 로직에 대해서 고려중입니다.
   ```java
       @Transactional
    public PaymentInfoDTO completePayment(String paymentKey) {

        PaymentDTO paymentDTO = paymentMapper.findByPaymentKeyWithLock(paymentKey)
                .orElseThrow(() -> new PaymentException.InvalidPaymentRequestException("결제 정보를 찾을 수 없습니다:" + paymentKey));

        validatePaymentStatusTransition(paymentDTO.getStatus(), PaymentStatus.COMPLETED);

        try {
            paymentDTO.setStatus(PaymentStatus.COMPLETED);

            PaymentLogDTO paymentLogDTO = PaymentLogDTO.builder()
                    .paymentId(paymentDTO.getPaymentId())
                    .action(PaymentLogAction.COMPLETE)
                    .status(PaymentStatus.COMPLETED)
                    .details("결제가 완료 처리되었습니다.")
                    .createdAt(LocalDateTime.now())
                    .build();

            paymentMapper.updatePayment(paymentDTO);
            paymentLogMapper.insertPaymentLog(paymentLogDTO);

            log.info("결제 완료 처리 성공: paymentKey={}", paymentKey);

            return PaymentInfoDTO.of(paymentDTO);
        } catch (Exception e) {
            log.error("결제 완료 처리 중 오류 발생: {}", e.getMessage(), e);
            throw new PaymentException.ProcessingException("결제 완료 처리 중 오류가 발생했습니다");
        }
    }
   ``` 

## 📝 참고 사항
- 외부 시스템 연동 : webClientService.sendCancelRequest는 외부 결제 게이트웨이(PG사)와 HTTP 요청을 통해 통신하며, 현재 동기 방식으로 처리됩니다. 타임아웃은 5초로 설정하였습니다.
- 트랜잭션 관리 : 결제 상태 업데이트와 로그 기록은 동일 트랜잭션 내에서 처리되며, 데이터베이스 락(findByPaymentKeyWithLock)을 사용하여 동시성 문제를 방지하였습니다.

## 🚀 향후 개선 방향
- 기존에는 비동기 요청/응답 처리로 외부 요청 서비스를 한 트랜잭션 내에서 처리하였으나, 동기 방식 요청이 추가됨에 따라 트랜잭션 분리가 필요해졌습니다. 이를 위해 직후의 릴리즈에서 트랜잭션 분리를 진행할 예정입니다.